### PR TITLE
Update libicyque.c

### DIFF
--- a/libicyque.c
+++ b/libicyque.c
@@ -1028,7 +1028,7 @@ icq_process_event(IcyQueAccount *ia, const gchar *event_type, JsonObject *data)
 					msg_flags = PURPLE_MESSAGE_SEND;
 					
 					const gchar *wid = json_object_get_string_member(message, "wid");
-					if (g_hash_table_remove(ia->sent_messages_hash, wid)) {
+					if (!wid || g_hash_table_remove(ia->sent_messages_hash, wid)) {
 						// We sent this message from Pidgin
 						continue;
 					}


### PR DESCRIPTION
Fixes the crash as mentioned in https://github.com/EionRobb/icyque/issues/17 as it now does not try to remove stuff from the hash_table when wid is NULL